### PR TITLE
Added `coffee-script` support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 
 babel:
-	babel lib -d build
-	babel ext -d build/ext
-
+	./node_modules/.bin/babel lib -d build
+	./node_modules/.bin/babel ext -d build/ext

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ module.exports = {
   extensions: {
     // clojurescript: require('./ext/clojurescript'),
     clojurescript: require('./build/ext/clojurescript'),
-    babel: require('./build/ext/babel'),
+    coffee: require('./build/ext/coffee'),
+    babel: require('./build/ext/babel')
   }
 }
-

--- a/ext/coffee.js
+++ b/ext/coffee.js
@@ -1,0 +1,20 @@
+
+export default function (ctx, args, done) {
+  let coffee = require('coffee-script')
+  done(null, {
+    block: {
+      coffee: {
+        transform(ctx, args, code, out, done) {
+          const opts = { }
+          try {
+            code = coffee.compile(code, opts)
+          } catch (err) {
+            return done(err)
+          }
+          console.log('coffee->\n', code)
+          done(null, code)
+        }
+      },
+    },
+  })
+}

--- a/package.json
+++ b/package.json
@@ -15,12 +15,18 @@
   "bugs": {
     "url": "https://github.com/notablemind/jupyter-nodejs/issues"
   },
-  "files": ["build", "lib", "install.js", "config.js"],
+  "files": [
+    "build",
+    "lib",
+    "install.js",
+    "config.js"
+  ],
   "prepublish": "make",
   "license": "ISC",
   "dependencies": {
     "async": "^0.9.0",
     "babel": "^5.1.11",
+    "coffee-script": "^1.9.2",
     "contextify": "^0.1.13",
     "superagent": "^1.2.0",
     "zmq": "^2.11.0"


### PR DESCRIPTION
- added `coffee-script` support (aliased as just `coffee`).
- fixed build so that it doesn't require `babel` to be installed globally.