### PR TITLE
Simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jupyter/notebook
+
+COPY . /root/jupyter-nodejs
+WORKDIR /root/jupyter-nodejs
+
+RUN mkdir -p /root/.ipython/kernels/nodejs/
+RUN npm install
+RUN node install.js
+RUN make
+
+CMD sh -c 'jupyter notebook --NotebookApp.port=8888 --no-browser --ip=* --debug'
+
+EXPOSE 8888


### PR DESCRIPTION
A simple Dockerfile to run Jupyter with the nodejs kernel.

Base image: jupyter/notebook

Image to test is available here: [ebutech/jupyter-nodejs](https://hub.docker.com/r/ebutech/jupyter-nodejs/)


