### PR TITLE
Tolerate multiple ZMQ identities

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -50,7 +50,7 @@ export default class Kernel {
     }
   }
 
-  // uuid, delim, hmac, header, parent_header, metadata, content
+  // uuids, delim, hmac, header, parent_header, metadata, content
   onShell() {
     const strs = [].map.call(arguments, a => a.toString())
     let i
@@ -59,34 +59,33 @@ export default class Kernel {
         break
       }
     }
-    const idents = [].slice.call(arguments, 0, i)
+    const uuids = [].slice.call(arguments, 0, i)
     const args = strs.slice(i + 2)
-    const uuid = idents[idents.length - 1]
     let [header, parent_header, metadata, content] = args
 
     header = JSON.parse(header)
     if (header.msg_type === 'kernel_info_request') {
-      this.send('shell', uuid, 'kernel_info_reply', info, header)
+      this.send('shell', uuids, 'kernel_info_reply', info, header)
       return
     }
     if (header.msg_type === 'history_request') {
-      this.send('shell', uuid, 'history_reply', {history: []}, header)
+      this.send('shell', uuids, 'history_reply', {history: []}, header)
       return
     }
 
     metadata = JSON.parse(metadata)
     content = JSON.parse(content)
     if (header.msg_type === 'execute_request') {
-      this.executeRequest(uuid, header, metadata, content)
+      this.executeRequest(uuids, header, metadata, content)
       return
     }
     if (header.msg_type === 'complete_request') {
-      this.completeRequest(uuid, header, metadata, content)
+      this.completeRequest(uuids, header, metadata, content)
       return
     }
     if (header.msg_type === 'shutdown_request') {
       this.ctx.shutdown()
-      this.send('shell', uuid, 'shutdown_response', content, header)
+      this.send('shell', uuids, 'shutdown_response', content, header)
       return
     }
     console.log('Unknown message type: ', header.msg_type)
@@ -96,18 +95,18 @@ export default class Kernel {
   }
 
   ioPub(msg_type, content, parent) {
-    this.send('iopub', get_uuid(), msg_type, content, parent)
+    this.send('iopub', [get_uuid()], msg_type, content, parent)
   }
 
-  completeRequest(uuid, header, metadata, content) {
+  completeRequest(uuids, header, metadata, content) {
     this.ctx.complete(content.code, content.cursor_pos, metadata.variant, (error, completions) => {
       if (error) {
         console.log(error)
-        return this.send('shell', uuid, 'complete_reply', {
+        return this.send('shell', uuids, 'complete_reply', {
           status: 'err'
         }, header)
       }
-      this.send('shell', uuid, 'complete_reply', completions, header)
+      this.send('shell', uuids, 'complete_reply', completions, header)
     })
   }
 
@@ -134,7 +133,7 @@ export default class Kernel {
     }, header)
   }
 
-  executeRequest(uuid, header, metadata, content) {
+  executeRequest(uuids, header, metadata, content) {
     this.ioPub('status', {execution_state: 'busy'}, header)
     this.count += 1
     this.ioPub('execute_input', {
@@ -152,7 +151,7 @@ export default class Kernel {
           evalue: error.message,
           traceback: [error.stack],
         }, header)
-        this.send('shell', uuid, 'execute_reply', {
+        this.send('shell', uuids, 'execute_reply', {
           status: 'error',
           ename: 'Runtime error',
           evalue: error.message,
@@ -170,7 +169,7 @@ export default class Kernel {
             data: result,
           }, header)
         }
-        this.send('shell', uuid, 'execute_reply', {
+        this.send('shell', uuids, 'execute_reply', {
           status: 'ok',
           execution_count: this.count,
           user_expressions: {},
@@ -201,14 +200,14 @@ export default class Kernel {
     return res
   }
 
-  _send(sock, id, header, parent, metadata, content) {
+  _send(sock, ids, header, parent, metadata, content) {
     const toHash = [
       json(header),
       json(parent),
       json(metadata || {}),
       json(content)]
     const hmac = this.hash(toHash.join(''))
-    const data = [id, DELIM, hmac].concat(toHash)
+    const data = ids.concat([DELIM, hmac]).concat(toHash)
     this.sockets[sock].send(data)
   }
 }
@@ -220,4 +219,3 @@ function fixUnicode(val) {
 function json(data) {
   return fixUnicode(JSON.stringify(data))
 }
-


### PR DESCRIPTION
Jupyter requests can possibly include multiple ZMQ identities, see here: http://jupyter-client.readthedocs.io/en/latest/messaging.html#the-wire-protocol