### PR TITLE
Fix Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,32 @@
-FROM jupyter/notebook
+FROM jupyter/base-notebook
 
-COPY . /root/jupyter-nodejs
-WORKDIR /root/jupyter-nodejs
+USER root
+RUN wget -O - https://deb.nodesource.com/setup_5.x | bash
+RUN apt-get install -y nodejs g++ make software-properties-common libzmq3-dev
 
-RUN mkdir -p /root/.ipython/kernels/nodejs/
+RUN mkdir -p $HOME/jupyter-nodejs
+COPY . $HOME/jupyter-nodejs
+RUN chown -R $NB_USER $HOME/jupyter-nodejs
+WORKDIR $HOME/jupyter-nodejs
+RUN touch /etc/ld.so.conf
+RUN echo "/opt/conda/lib" >> /etc/ld.so.conf
+
+# RUN add-apt-repository ppa:chris-lea/zeromq -y
+# RUN add-apt-repository ppa:chris-lea/libpgm -y
+# RUN apt-get update
+RUN conda install -y jupyter_console
+
+USER $NB_USER
+RUN mkdir -p $HOME/.ipython/kernels/nodejs/
 RUN npm install
 RUN node install.js
-RUN make
+RUN npm run build
+RUN npm run build-ext
+WORKDIR $HOME/jupyter-nodejs/node_modules/zmq/
+RUN npm run install
 
-CMD sh -c 'jupyter notebook --NotebookApp.port=8888 --no-browser --ip=* --debug'
+USER root
+WORKDIR $HOME/jupyter-nodejs
+RUN ldconfig
 
 EXPOSE 8888

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-
-babel:
-	./node_modules/.bin/babel lib -d build
-	./node_modules/.bin/babel ext -d build/ext

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,8 @@ Get it while it's hot! or view the [example notebook](http://nbviewer.ipython.or
 git clone git@github.com:notablemind/jupyter-nodejs.git
 mkdir -p ~/.ipython/kernels/nodejs/
 npm install && node install.js
-make
+npm run build
+npm run build-ext
 ipython console --kernel nodejs
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "build": "babel lib -d build",
+    "build-ext": "babel ext -d build/ext",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Jared Forsyth",
@@ -31,7 +33,7 @@
     "contextify": "^0.1.13",
     "mkdirp": "^0.5.1",
     "superagent": "^1.2.0",
-    "zmq": "^2.11.0"
+    "zmq": "^2.15.3"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0"


### PR DESCRIPTION
I've just fixed the Dockerfile, you can try it by running `docker run -it -d -p 11111:8888 kxxoling/jupyter-nodejs`, and open http://localhost:11111 to have a preview.

But `%%babel` is not working for issue https://github.com/notablemind/jupyter-nodejs/issues/32 . And why I choose node 5.12 is node 6 would cause `Module version mismatch. Expected 48, got 47` error that I can't fixed it although tried.
