### PR TITLE
Use correct file_extension format

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -9,7 +9,7 @@ export default {
     'name': 'nodejs',
     'version': '0.10',
     'mimetype': 'text/javascript',
-    'file_extension': 'js',
+    'file_extension': '.js',
     'pygments_lexer': 'javascript',
     'codemirror_mode': 'javascript',
   },


### PR DESCRIPTION
Addresses https://github.com/notablemind/jupyter-nodejs/issues/35. Jupyter notebook expects the `file_extension` to have a `.` in front of it.