### PR TITLE
Small Windows fix to "install.js" (user home directory variable)

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,7 +3,12 @@ var fs = require('fs')
 var path = require('path')
 var mkdirp = require('mkdirp')
 
-var installPath = path.join(process.env.HOME, '.ipython/kernels/nodejs')
+var userHome = process.env.HOME;
+if (process.platform === "win32") {
+  userHome = process.env.USERPROFILE;
+}
+
+var installPath = path.join(userHome, '.ipython/kernels/nodejs')
 if (process.argv.length >= 3) {
   installPath = process.argv[2]
 }


### PR DESCRIPTION
On Windows platforms, `USERPROFILE` holds the path to the user's home directory rather than `HOME`. (`HOME` is left undefined) This patch makes `install.js` check if the platform is `win32` and -- if so -- use that variable instead.