### PR TITLE
Update socket.js to use zeromq instead of zmq

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -1,6 +1,6 @@
 
 import async from 'async'
-import zmq from 'zmq'
+import zeromq from 'zeromq'
 
 export default function setupSockets(config, done) {
   const sockets = {
@@ -33,7 +33,7 @@ export default function setupSockets(config, done) {
 }
 
 function setupSocket(config, general, done) {
-  const sock = zmq.socket(config.type);
+  const sock = zeromq.socket(config.type);
   const addr = general.transport + '://' + general.ip + ':' + config.port
   sock.bind(addr, err => {
     // console.log('sock', addr, err)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "coffee-script": "^1.9.2",
     "mkdirp": "^0.5.1",
     "superagent": "^1.2.0",
-    "zmq": "^2.15.3"
+    "zeromq": "^4.6.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0"


### PR DESCRIPTION
This is a potential fix for #56 that replaces the `zmq` package with `zeromq` and removes the compilation of ZeroMQ from source. I believe this will also simplify the Dockerfile although I have not tackled that yet.
Feedback appreciated, thanks for the great work!