### PR TITLE
[WIP] update to work on top of the current docker-stacks jupyter images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM jupyter/base-notebook
+#my objective would be to get it to work on top of this one instead,
+# but for now let's keep it simple
+#FROM jupyter/scipy-notebook:latest
 
 USER root
-RUN wget -O - https://deb.nodesource.com/setup_5.x | bash
-RUN apt-get install -y nodejs g++ make software-properties-common libzmq3-dev
+# need gnupg2 to run node setup
+RUN apt-get update && apt-get install -y nodejs g++ make software-properties-common libzmq3-dev gnupg2
+# upgraded to latest supported version
+RUN wget -O - https://deb.nodesource.com/setup_10.x | bash
+
+# this probably is not helpful, I just gave it a try in the hope it would clear up the issues a little
+RUN conda update -n base conda
 
 RUN mkdir -p $HOME/jupyter-nodejs
 COPY . $HOME/jupyter-nodejs


### PR DESCRIPTION
Hi

was giving this a try on top of the current docker-stacks image

I've been able to iron out the most obvious issues, but am stuck at this point -- see logs below

there seems to be similar issues experienced here <https://github.com/nodejs/node-gyp/issues/1528> but I still can't very well see how to work my way through.

please let me know whether this is of any interest at all, or if you consider this as deprecated or broken beyond repair; do you know of any alternative to write javascript notebooks ? 


thanks

```
docker build -t jupyter-nodejs .
Sending build context to Docker daemon 255.5 kB
Step 1/24 : FROM jupyter/base-notebook
 ---> 61a46d4f4e51
Step 2/24 : USER root
 ---> Using cache
 ---> 994069b04b3c
Step 3/24 : RUN apt-get update && apt-get install -y nodejs g++ make software-properties-common libzmq3-dev gnupg2
 ---> Using cache
 ---> 6eef053101ea
Step 4/24 : RUN wget -O - https://deb.nodesource.com/setup_10.x | bash
 ---> Using cache
 ---> 67958c66bab9
Step 5/24 : RUN conda update -n base conda
 ---> Using cache
 ---> 681a3c326f6a
Step 6/24 : RUN mkdir -p $HOME/jupyter-nodejs
 ---> Using cache
 ---> cf33c52fd138
Step 7/24 : COPY . $HOME/jupyter-nodejs
 ---> aaa66d19f7ef
Removing intermediate container 146a2c31a331
Step 8/24 : RUN chown -R $NB_USER $HOME/jupyter-nodejs
 ---> Running in f785b8df1767
 ---> fce2e7b00b32
Removing intermediate container f785b8df1767
Step 9/24 : WORKDIR $HOME/jupyter-nodejs
 ---> 24563f6d8d3b
Removing intermediate container dbc12f7c1aff
Step 10/24 : RUN touch /etc/ld.so.conf
 ---> Running in 3e45f830cce7
 ---> d51978631d02
Removing intermediate container 3e45f830cce7
Step 11/24 : RUN echo "/opt/conda/lib" >> /etc/ld.so.conf
 ---> Running in ba5898e523d2
 ---> bd555523e0da
Removing intermediate container ba5898e523d2
Step 12/24 : RUN conda install -y jupyter_console
 ---> Running in d1725e6a1ed7
Collecting package metadata: ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /opt/conda

  added / updated specs:
    - jupyter_console


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    jupyter_console-6.0.0      |             py_0          19 KB  conda-forge
    ------------------------------------------------------------
                                           Total:          19 KB

The following NEW packages will be INSTALLED:

  jupyter_console    conda-forge/noarch::jupyter_console-6.0.0-py_0



Downloading and Extracting Packages
jupyter_console-6.0. | 19 KB     | ########## | 100%
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
 ---> 734a6bf76a28
Removing intermediate container d1725e6a1ed7
Step 13/24 : USER $NB_USER
 ---> Running in 3a8a410a178e
 ---> 1744fa8c3ca7
Removing intermediate container 3a8a410a178e
Step 14/24 : RUN mkdir -p $HOME/.ipython/kernels/nodejs/
 ---> Running in 183f5d5a6084
 ---> f52ed0283c9f
Removing intermediate container 183f5d5a6084
Step 15/24 : RUN npm install
 ---> Running in 0763149ec726
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

> zmq@2.15.3 install /home/jovyan/jupyter-nodejs/node_modules/zmq
> node-gyp rebuild

gyp ERR! configure error
gyp ERR! stack Error: Command failed: /opt/conda/bin/python -c import sys; print "%s.%s.%s" % sys.version_info[:3];
gyp ERR! stack   File "<string>", line 1
gyp ERR! stack     import sys; print "%s.%s.%s" % sys.version_info[:3];
gyp ERR! stack                                ^
gyp ERR! stack SyntaxError: invalid syntax
gyp ERR! stack
gyp ERR! stack     at ChildProcess.exithandler (child_process.js:297:12)
gyp ERR! stack     at ChildProcess.emit (events.js:197:13)
gyp ERR! stack     at maybeClose (internal/child_process.js:984:16)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:265:5)
gyp ERR! System Linux 4.20.13-200.fc29.x86_64
gyp ERR! command "/opt/conda/bin/node" "/opt/conda/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/jovyan/jupyter-nodejs/node_modules/zmq
gyp ERR! node -v v11.11.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm WARN The package mkdirp is included as both a dev and production dependency.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! zmq@2.15.3 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the zmq@2.15.3 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jovyan/.npm/_logs/2019-03-11T15_38_02_908Z-debug.log
The command '/bin/sh -c npm install' returned a non-zero code: 1
```